### PR TITLE
Update JTProximitySDK to 1.12.0 in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,7 +43,7 @@
             <string>$ENABLE_CMP</string>
         </config-file>
         <source-file src="src/ios/KaribooPlugin.m"/>
-        <framework src="JTProximitySDK" type="podspec" spec="~> 1.9.0"/>
+        <framework src="JTProximitySDK" type="podspec" spec="~> 1.12.0"/>
     </platform>
     <platform name="android">
         <config-file parent="/*" target="res/xml/config.xml">


### PR DESCRIPTION
That change is needed in a Capacitor app to get the dependency, otherwise we get this error:

`None of your spec sources contain a spec satisfying the dependency: `JTProximitySDK (~> 1.9.0)`.`